### PR TITLE
Fixed issue with missing label warning

### DIFF
--- a/src/packages/transitions/src/Components/FluidTransitions/useInterpolatorContext.tsx
+++ b/src/packages/transitions/src/Components/FluidTransitions/useInterpolatorContext.tsx
@@ -5,7 +5,7 @@ import {
   PartialInterpolatorInfo,
 } from "../Types";
 import { useForceUpdate, useLog } from "../../Hooks";
-import { fluidException, LoggerLevel } from "../../Types";
+import { LoggerLevel } from "../../Types";
 
 /**
  *
@@ -31,23 +31,24 @@ export const useInterpolatorContext = (
 
   if (setupInterpolators && !interpolatorEntry.current) {
     if (!label) {
-      throw fluidException(
+      console.warn(
         "All components exposing interpolators must be named through the label property.",
       );
+    } else {
+      interpolatorEntry.current = {
+        label: label,
+        ...setupInterpolators(props),
+      };
+      logger(
+        () =>
+          "Registered " +
+          (interpolatorEntry.current &&
+            Object.keys(interpolatorEntry.current.interpolators).join(", ")) +
+          " in " +
+          label,
+        LoggerLevel.Detailed,
+      );
     }
-    interpolatorEntry.current = {
-      label: label,
-      ...setupInterpolators(props),
-    };
-    logger(
-      () =>
-        "Registered " +
-        (interpolatorEntry.current &&
-          Object.keys(interpolatorEntry.current.interpolators).join(", ")) +
-        " in " +
-        label,
-      LoggerLevel.Detailed,
-    );
   }
 
   /******************************************************


### PR DESCRIPTION
Changed exception to warning when a component with interpolators are created without a label

Closes #9 